### PR TITLE
Enable lib to be used in browser

### DIFF
--- a/lib/sizeof.js
+++ b/lib/sizeof.js
@@ -1,10 +1,16 @@
 "use strict";
 
 // get bytes in string
-// https://stackoverflow.com/a/5515960/591487
-function lengthInUtf8Bytes(str) {
-  var m = encodeURIComponent(str).match(/%[89ABab]/g);
-  return str.length + (m ? m.length : 0);
+// https://stackoverflow.com/a/23329386/591487
+function byteLength(str) {
+  // returns the byte length of an utf8 string
+  var s = str.length;
+  for (var i=str.length-1; i>=0; i--) {
+    var code = str.charCodeAt(i);
+    if (code > 0x7f && code <= 0x7ff) s++;
+    else if (code > 0x7ff && code <= 0xffff) s+=2;
+  }
+  return s;
 }
 
 function sizeOfObject(object) {
@@ -20,6 +26,11 @@ function sizeOfObject(object) {
     typeof object.getDate === "function"
   )
     return 8;
+  //Blob
+  if (typeof object.toUint8Array === "function"){
+    var blob = object.toUint8Array();
+    return blob.byteLength;
+  }
   //Reference
   if (typeof object.onSnapshot === "function") {
     return object["_key"]["path"]["segments"]
@@ -54,7 +65,7 @@ function sizeof(object) {
   var objectType = typeof object;
   switch (objectType) {
     case "string":
-      return lengthInUtf8Bytes(object) + 1;
+      return byteLength(object) + 1;
     case "boolean":
       return 1;
     case "number":

--- a/lib/sizeof.js
+++ b/lib/sizeof.js
@@ -1,5 +1,11 @@
 "use strict";
-var Buffer = require("buffer").Buffer;
+
+// get bytes in string
+// https://stackoverflow.com/a/5515960/591487
+function lengthInUtf8Bytes(str) {
+  var m = encodeURIComponent(str).match(/%[89ABab]/g);
+  return str.length + (m ? m.length : 0);
+}
 
 function sizeOfObject(object) {
   if (object === null) {
@@ -44,14 +50,11 @@ function sizeOfObject(object) {
 }
 
 function sizeof(object) {
-  if (Buffer.isBuffer(object)) {
-    return object.length;
-  }
 
   var objectType = typeof object;
   switch (objectType) {
     case "string":
-      return Buffer.from(object).length + 1;
+      return lengthInUtf8Bytes(object) + 1;
     case "boolean":
       return 1;
     case "number":

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-size",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "firestore-size",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "Calculates the approximate size of Firestore document.",
   "repository": "https://github.com/alekslario/firestore-size.git",
   "main": "index.js",

--- a/test/buffer-vs-fn.js
+++ b/test/buffer-vs-fn.js
@@ -1,0 +1,21 @@
+// test string length function against Buffer
+var assert = require("assert"),
+  Buffer = require("buffer").Buffer;
+
+function lengthInUtf8Bytes(str) {
+  var m = encodeURIComponent(str).match(/%[89ABab]/g);
+  return str.length + (m ? m.length : 0);
+}
+function bufferSize(str) {
+  return Buffer.from(str).length;
+}
+describe("string byte length function is accurate", () => {
+  it("produces the same result as using Buffer", () => {
+
+    const tests = ["Hello world", "åß∂ƒ", "ثبهخنى", "你好", "ха ха...шутка что ли?"];
+
+    tests.forEach(item => {
+      assert.equal(lengthInUtf8Bytes(item), bufferSize(item));
+    });
+  });
+});

--- a/test/buffer-vs-fn.js
+++ b/test/buffer-vs-fn.js
@@ -12,7 +12,7 @@ function bufferSize(str) {
 describe("string byte length function is accurate", () => {
   it("produces the same result as using Buffer", () => {
 
-    const tests = ["Hello world", "åß∂ƒ", "ثبهخنى", "你好", "ха ха...шутка что ли?"];
+    const tests = ["Hello world", "åß∂ƒ", "ثبهخنى", "你好", "ха ха...шутка что ли?", ""];
 
     tests.forEach(item => {
       assert.equal(lengthInUtf8Bytes(item), bufferSize(item));

--- a/test/buffer-vs-fn.js
+++ b/test/buffer-vs-fn.js
@@ -2,9 +2,15 @@
 var assert = require("assert"),
   Buffer = require("buffer").Buffer;
 
-function lengthInUtf8Bytes(str) {
-  var m = encodeURIComponent(str).match(/%[89ABab]/g);
-  return str.length + (m ? m.length : 0);
+function byteLength(str) {
+  // returns the byte length of an utf8 string
+  var s = str.length;
+  for (var i=str.length-1; i>=0; i--) {
+    var code = str.charCodeAt(i);
+    if (code > 0x7f && code <= 0x7ff) s++;
+    else if (code > 0x7ff && code <= 0xffff) s+=2;
+  }
+  return s;
 }
 function bufferSize(str) {
   return Buffer.from(str).length;
@@ -15,7 +21,7 @@ describe("string byte length function is accurate", () => {
     const tests = ["Hello world", "åß∂ƒ", "ثبهخنى", "你好", "ха ха...шутка что ли?", ""];
 
     tests.forEach(item => {
-      assert.equal(lengthInUtf8Bytes(item), bufferSize(item));
+      assert.equal(byteLength(item), bufferSize(item));
     });
   });
 });


### PR DESCRIPTION
This is a nice little lib! I tried to use it in the browser, but it errored because it was using `Buffer`.

I replaced Buffer with a function that calculates bytes in a string, and also added a test to ensure the function is accurate.