### PR TITLE
Add support for typescript and default export

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,5 @@
+declare module "firestore-size" {
+
+  export default function sizeof(object: Record < string, any > ): number
+
+}

--- a/lib/sizeof.js
+++ b/lib/sizeof.js
@@ -87,3 +87,4 @@ function sizeOfDoc(object) {
   return 32 + sizeof(object);
 }
 module.exports = sizeOfDoc;
+module.exports.default = sizeOfDoc;

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Calculates the approximate size of Firestore document.",
   "repository": "https://github.com/alekslario/firestore-size.git",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "mocha -t test/"
   },


### PR DESCRIPTION
- This adds support for typescript projects
- Fixes default export, when using babel or other tools, simply importing it as:
```
import sizeof from "firestore-size"
````
would fail because it looks for default export 


PS: Thank you very much for this lib! Was almost starting to write my own because I was frustrated but luckily I found this :) 